### PR TITLE
Allow test_path to accept a test file or profile dir and validate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,8 @@ jobs:
         on:
           repo: jrbeilke/packer-provisioner-inspec
           tags: true
+
+stages:
+  - test
+  - release
+    if: tag = true

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ required parameters
 optional parameters
 ------
 
+- `extra_arguments` (array of strings) - An array of extra arguments to pass to the inspec command. By default, this is empty. These arguments will be passed through a shell and arguments should be quoted accordingly. Usage example: `"extra_arguments": ["--sudo", "--no-distinct-exit"]`
 - `local_port` (string) - The port on which inspec-provisioner should first
   attempt to listen for SSH connections. This value is a starting point.
 	inspec-provisioner will attempt listen for SSH connections on the first

--- a/provisioner.go
+++ b/provisioner.go
@@ -87,7 +87,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	var errs *packer.MultiError
-	err = validateFileConfig(p.config.TestPath, "test_path", true)
+	err = validateTestPathConfig(p.config.TestPath)
 	if err != nil {
 		errs = packer.MultiErrorAppend(errs, err)
 	}
@@ -345,6 +345,14 @@ func validateFileConfig(name string, config string, req bool) error {
 		return fmt.Errorf("%s: %s is invalid: %s", config, name, err)
 	} else if info.IsDir() {
 		return fmt.Errorf("%s: %s must point to a file", config, name)
+	}
+	return nil
+}
+
+func validateTestPathConfig(name string) error {
+	_, err := os.Stat(name)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("test_path: %s does not exist: %s", name, err)
 	}
 	return nil
 }

--- a/provisioner_test.go
+++ b/provisioner_test.go
@@ -123,6 +123,18 @@ func TestProvisionerPrepare_TestFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+
+	test_dir, err := ioutil.TempDir("", "example")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(test_dir)
+
+	config["test_path"] = test_dir
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestProvisionerPrepare_HostKeyFile(t *testing.T) {


### PR DESCRIPTION
Resolves #4 

Also added a quick note to the README about using the "extra_arguments" parameter