### PR TITLE
Fully support Inspec attributes files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ required parameters
 optional parameters
 ------
 
-- `extra_arguments` (array of strings) - An array of extra arguments to pass to the inspec command. By default, this is empty. These arguments will be passed through a shell and arguments should be quoted accordingly. Usage example: `"extra_arguments": ["--sudo", "--no-distinct-exit"]`
+- `attrs` (array of strings) - An array of attribute files to pass to the inspec command.
+- `extra_arguments` (array of strings) - An array of extra arguments to pass to the inspec command.
+  By default, this is empty. These arguments will be passed through a shell and arguments should be
+  quoted accordingly. Usage example: `"extra_arguments": ["--sudo", "--no-distinct-exit"]`
 - `local_port` (string) - The port on which inspec-provisioner should first
   attempt to listen for SSH connections. This value is a starting point.
 	inspec-provisioner will attempt listen for SSH connections on the first

--- a/provisioner.go
+++ b/provisioner.go
@@ -295,7 +295,7 @@ func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, priv
 
 		for _, attr := range p.config.Attrs {
 			attr_path, _ := filepath.Abs(attr)
-			attr_args = append(args, attr_path)
+			attr_args = append(attr_args, attr_path)
 		}
 
 		args = append(args, strings.Join(attr_args, " "))

--- a/provisioner.go
+++ b/provisioner.go
@@ -286,9 +286,11 @@ func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, priv
 	if len(privKeyFile) > 0 {
 		args = append(args, "-i", privKeyFile)
 	}
+
 	if len(p.config.ProfilesPath) > 0 {
 		args = append(args, "--profiles-path", p.config.ProfilesPath)
 	}
+
 	if len(p.config.Attrs) > 0 {
 		var attr_args []string
 		attr_args = append(attr_args, "--attrs")
@@ -298,7 +300,7 @@ func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, priv
 			attr_args = append(attr_args, attr_path)
 		}
 
-		args = append(args, strings.Join(attr_args, " "))
+		args = append(args, attr_args...)
 	}
 
 	args = append(args, p.config.ExtraArguments...)

--- a/provisioner_test.go
+++ b/provisioner_test.go
@@ -267,6 +267,51 @@ func TestProvisionerPrepare_LocalPort(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_Attrs(t *testing.T) {
+	var p Provisioner
+	config := testConfig(t)
+	defer os.Remove(config["command"].(string))
+
+	hostkey_file, err := ioutil.TempFile("", "hostkey")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(hostkey_file.Name())
+
+	publickey_file, err := ioutil.TempFile("", "publickey")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(publickey_file.Name())
+
+	test_file, err := ioutil.TempFile("", "example")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(test_file.Name())
+
+	config["ssh_host_key_file"] = hostkey_file.Name()
+	config["ssh_authorized_key_file"] = publickey_file.Name()
+	config["test_path"] = test_file.Name()
+
+	// Test passing an Attrs file
+	attributes_file, err := ioutil.TempFile("", "attributes")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(attributes_file.Name())
+
+	config["attrs"] = attributes_file.Name()
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if p.config.Attrs != attributes_file.Name() {
+		t.Errorf("expected Attrs to be set")
+	}
+}
+
 func TestInspecGetVersion(t *testing.T) {
 	if os.Getenv("PACKER_ACC") == "" {
 		t.Skip("This test is only run with PACKER_ACC=1 and it requires InSpec to be installed")

--- a/provisioner_test.go
+++ b/provisioner_test.go
@@ -301,13 +301,13 @@ func TestProvisionerPrepare_Attrs(t *testing.T) {
 	}
 	defer os.Remove(attributes_file.Name())
 
-	config["attrs"] = attributes_file.Name()
+	config["attrs"] = []string{attributes_file.Name()}
 	err = p.Prepare(config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if p.config.Attrs != attributes_file.Name() {
+	if p.config.Attrs[0] != attributes_file.Name() {
 		t.Errorf("expected Attrs to be set")
 	}
 }


### PR DESCRIPTION
Change `Attrs` to be a `string`.
Add validation for filepath.
Pass through to Inspec CLI if set.
Add test coverage.