### PR TITLE
Add support for providing a list of 'valid exit codes' for the Inspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ optional parameters
   `/usr/lib/sftp-server -e`.
 - `ssh_host_key_file` - The SSH key that will be used to run the SSH server to which InSpec connects.
 - `ssh_authorized_key_file` - The SSH public key of the InSpec `ssh_user`.
+- `valid_exit_codes` (array of ints) - An array of valid exit codes to accept.

--- a/provisioner.go
+++ b/provisioner.go
@@ -344,7 +344,6 @@ func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, priv
 			// an ExitStatus() method with the same signature.
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 				exitStatus := status.ExitStatus()
-				log.Printf("[DEBUG] Exit Status: %d", exitStatus)
 				// Check exit code against allowed codes (likely just 0)
 				validExitCode := false
 				for _, v := range p.config.ValidExitCodes {
@@ -359,8 +358,7 @@ func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, priv
 				}
 			}
 		} else {
-			log.Fatalf("cmd.Wait: %v", err)
-			return err
+			return fmt.Errorf("Unable to get exit status: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Inspec can exit with a non-zero exit code but still pass...

> If all tests passed (no fails, no skips) exit code 0 is returned. If some tests skipped but none failed, exit code 101 is returned. If at least one test failed, exit code 100 is returned. If inspec failed for any other reason, exit code 1 is returned.

Source: https://www.inspec.io/docs/reference/cli/#exec